### PR TITLE
Fix typo to display missing dependency correctly

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -30,7 +30,7 @@ util.notValid = function(commandName) {
 
 util.missingDependency = function(dependencyName) {
   console.log(' ');
-  console.log(dep + ' not found'.red);
+  console.log(dependencyName + ' not found'.red);
   console.log('Please install missing dependency'.red)
 }
 


### PR DESCRIPTION
Someone in the google group found this while trying to create a project on a CentOS machine, presumably without Git installed.