### PR TITLE
Fix missing repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
   },
   "author": "P'unk Avenue",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/punkave/apostrophe-cli.git"
+  },
   "dependencies": {
     "colors": "~1.0.x",
     "commander": "~2.5.x",


### PR DESCRIPTION
This fixes `npm WARN apostrophe-cli@2.0.1 No repository field.`