### PR TITLE
Fix outdated replace dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "colors": "~1.0.x",
     "commander": "~2.5.x",
     "prompt": "^0.2.14",
-    "replace": "~0.3.0",
+    "replace3": "0.6.2",
     "shelljs": "~0.3.x"
   },
   "preferGlobal": true,


### PR DESCRIPTION
This fixes:

```
npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```

The original `replace` package is unmaintained for some time
cf. https://github.com/harthur/replace

The living maintained fork for replace is now
https://github.com/yieme/replace, published as `replace3` on NPM:
https://www.npmjs.com/package/replace3