### PR TITLE
fix for replace module not being found

### DIFF
--- a/lib/commands/create-module.js
+++ b/lib/commands/create-module.js
@@ -1,5 +1,5 @@
 require('shelljs/global');
-var replace = require('replace');
+var replace = require('replace3');
 var prompt = require('prompt');
 var fs = require('fs');
 var util = require('../util');

--- a/lib/commands/create-piece.js
+++ b/lib/commands/create-piece.js
@@ -1,5 +1,5 @@
 require('shelljs/global');
-var replace = require('replace');
+var replace = require('replace3');
 var prompt = require('prompt');
 var fs = require('fs');
 var util = require('../util');

--- a/lib/commands/create-widget.js
+++ b/lib/commands/create-widget.js
@@ -1,5 +1,5 @@
 require('shelljs/global');
-var replace = require('replace');
+var replace = require('replace3');
 var prompt = require('prompt');
 var fs = require('fs');
 var util = require('../util');

--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -1,5 +1,5 @@
 require('shelljs/global');
-var replace = require('replace');
+var replace = require('replace3');
 var prompt = require('prompt');
 var util = require('../util');
 var config = require('../../config');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "colors": "~1.0.x",
     "commander": "~2.5.x",
     "prompt": "^0.2.14",
-    "replace3": "0.6.2",
+    "replace3": "^0.6.2",
     "shelljs": "~0.3.x"
   },
   "preferGlobal": true,


### PR DESCRIPTION
i believe newer node / npm changed how the module is named when it's installed as a dependency. would appreciate some help verifying that this works in node 4, not sure exactly when/where the change happened in how dependencies are installed. see https://github.com/punkave/apostrophe/issues/885